### PR TITLE
Remove heroku toolbelt.

### DIFF
--- a/bin/setup-vagrant.sh
+++ b/bin/setup-vagrant.sh
@@ -20,8 +20,6 @@ apt-get update
 apt-get -y upgrade
 apt-get -y install "${to_install[@]}"
 
-wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
-
 bin/setup-postgresql.sh
 bin/setup-rvm.sh
 


### PR DESCRIPTION
Since no one should be deploying manually there is not reason to install
this in our development environment.
